### PR TITLE
Write errors to stderr

### DIFF
--- a/ldaplist
+++ b/ldaplist
@@ -16,9 +16,9 @@ ldap_trace="/tmp/ldaplist." + str(os.getpid()) + ".trace"
 
 # print an error message and the default help(options parser object, error message)
 def die (parser, msg):
-    print msg
-    print
-    parser.print_help()
+    print >> sys.stderr, msg
+    print >> sys.stderr
+    parser.print_help(sys.stderr)
     sys.exit(1)
 
 # print debugging messages(string)


### PR DESCRIPTION
Errors from `die()` and `OptionParser.print_help()` were by default being written to `stdout`. This potentially confuses consumers of `ldaplist`'s output.
